### PR TITLE
Link to new wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - secrets
   -
 - enemies killed
-  - https://noita.fandom.com/wiki/Enemies
+  - https://noita.wiki.gg/wiki/Enemies
 ## nice to have
 - import wands?
 - backup saves easily?


### PR DESCRIPTION
The Noita wiki has migrated to noita.wiki.gg which is regularly updated